### PR TITLE
Feature/revamp maneuvers for new chassis feat(maneuver): Revamp turning logic and stabilize pre-turn movements

### DIFF
--- a/src/WRO2025_FE/src/driver/controller/controller/ackermann_original.py
+++ b/src/WRO2025_FE/src/driver/controller/controller/ackermann_original.py
@@ -5,11 +5,11 @@ import math
 from ros_robot_controller_msgs.msg import MotorState, MotorsState
 
 class RearDriveAckermannChassis: # Renamed class for clarity
-    def __init__(self, wheelbase=0.145, wheel_diameter=0.067, drive_motor_id=4, servo_offset_pulse=43): # Renamed parameter for clarity
+    def __init__(self, wheelbase=0.145, wheel_diameter=0.067, drive_motor_id=4, servo_offset_pulse=0): # Renamed parameter for clarity servo_offset_pulse=43
         self.wheelbase = wheelbase
         self.wheel_diameter = wheel_diameter
         self.DRIVE_MOTOR_ID = drive_motor_id # Store the single drive motor ID
-        self.SERVO_OFFSET_PULSE = servo_offset_pulse
+        # self.SERVO_OFFSET_PULSE = servo_offset_pulse
 
     def speed_covert(self, speed):
         """
@@ -18,7 +18,7 @@ class RearDriveAckermannChassis: # Renamed class for clarity
         return speed / (math.pi * self.wheel_diameter)
 
     def set_velocity(self, linear_speed, angular_speed, reset_servo=True):
-        servo_angle_pulse = 1500 + self.SERVO_OFFSET_PULSE 
+        servo_angle_pulse = 1500 # + self.SERVO_OFFSET_PULSE 
 
         # --- Steering Angle Calculation (This logic remains the same) ---
         if abs(linear_speed) >= 1e-8 and abs(angular_speed) >= 1e-8:

--- a/src/WRO2025_FE/src/driver/controller/controller/ackermann_original.py
+++ b/src/WRO2025_FE/src/driver/controller/controller/ackermann_original.py
@@ -5,10 +5,11 @@ import math
 from ros_robot_controller_msgs.msg import MotorState, MotorsState
 
 class RearDriveAckermannChassis: # Renamed class for clarity
-    def __init__(self, wheelbase=0.145, wheel_diameter=0.067, drive_motor_id=4): # Renamed parameter for clarity
+    def __init__(self, wheelbase=0.145, wheel_diameter=0.067, drive_motor_id=4, servo_offset_pulse=43): # Renamed parameter for clarity
         self.wheelbase = wheelbase
         self.wheel_diameter = wheel_diameter
         self.DRIVE_MOTOR_ID = drive_motor_id # Store the single drive motor ID
+        self.SERVO_OFFSET_PULSE = servo_offset_pulse
 
     def speed_covert(self, speed):
         """
@@ -17,18 +18,18 @@ class RearDriveAckermannChassis: # Renamed class for clarity
         return speed / (math.pi * self.wheel_diameter)
 
     def set_velocity(self, linear_speed, angular_speed, reset_servo=True):
-        servo_angle_pulse = 1500
+        servo_angle_pulse = 1500 + self.SERVO_OFFSET_PULSE 
 
         # --- Steering Angle Calculation (This logic remains the same) ---
         if abs(linear_speed) >= 1e-8 and abs(angular_speed) >= 1e-8:
             theta = math.atan(self.wheelbase * angular_speed / linear_speed)
-            theta_max = 29
+            theta_max = 50
             if abs(theta) > math.radians(theta_max):
                 theta = math.copysign(math.radians(theta_max), theta) 
             servo_angle_pulse = 1500 + 2000 * math.degrees(-theta) / 180
         
         # --- Drive Motor Speed Calculation ---
-        drive_motor_rps = -1 * self.speed_covert(linear_speed)
+        drive_motor_rps = self.speed_covert(linear_speed) # * -1
         
         # --- Create Motor Command Message for the single drive motor ---
         motor_data = []


### PR DESCRIPTION
This pull request introduces a major refactoring of the robot's turning and alignment logic to fully leverage the capabilities of the new high-agility v2 chassis. The previous complex maneuvers have been replaced with simpler, more robust, and faster alternatives.

### Key Changes:

1.  **Simplified Turning Maneuver**:
    - Replaced the multi-state reverse-turn sequence (`APPROACH`, `REVERSE`, etc.) with a single, streamlined `EXECUTE_TURN` state.
    - The new logic uses a PID-controlled approach followed by a direct, high-steer pivot turn, eliminating the need for complex reversing during corners.

2.  **Stabilized Pre-Turn Movements**:
    - All forward (`PLAN_NEXT_AVOIDANCE`) and reverse (`POSITIONING_REVERSE`) movements prior to a turn now use the PID wall alignment controller (`_execute_pid_alignment`).
    - This ensures the robot maintains a stable heading and distance from the wall, leading to more consistent and predictable entry into turns.

3.  **Robust Lane Change & Avoidance Logic**:
    - The completion check for `TURN_IN` during a lane change is now based on a more reliable stability counter, preventing premature transitions.
    - The logic to suppress distance-based steering (`dist_steer`) when approaching a corner has been added to prevent sudden jerks.

4.  **IMU System Refactor for Accuracy**:
    - The `yaw_publisher_node` has been updated to start in `NDOF_MODE` and apply full calibration data from a file at launch.
    - Implemented a robust "zeroing" procedure that correctly establishes a relative heading at startup, resolving persistent offset issues.
    - Unified all nodes (EKF and navigator) to use this single, more reliable IMU data source.

5.  **Code Cleanup**:
    - Removed a significant amount of dead code, including obsolete sub-states, deprecated ROS parameters, and unused helper functions related to the legacy turning logic.